### PR TITLE
include four snackbar color options

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,24 +1,62 @@
 // Styles from this file will override 'vendors.scss' and SEED's base styles.
-.success-snackbar  {
-  --mat-snack-bar-button-color: #fff;
-  --mdc-snackbar-container-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
-  --mdc-snackbar-supporting-text-color: #fff;
-}
+.mat-mdc-snack-bar-container {
+  &.success-snackbar  {
+    --mat-snack-bar-button-color: #fff;
+    --mdc-snackbar-container-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
+    --mdc-snackbar-supporting-text-color: #fff;
+  }
 
-.info-snackbar {
-  --mat-snack-bar-button-color: #fff;
-  --mdc-snackbar-container-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
-  --mdc-snackbar-supporting-text-color: #fff;
-}
+  &.info-snackbar {
+    --mat-snack-bar-button-color: #fff;
+    --mdc-snackbar-container-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+    --mdc-snackbar-supporting-text-color: #fff;
+  }
 
-.alert-snackbar {
-  --mat-snack-bar-button-color: #fff;
-  --mdc-snackbar-container-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
-  --mdc-snackbar-supporting-text-color: #fff;
-}
+  &.alert-snackbar {
+    --mat-snack-bar-button-color: #fff;
+    --mdc-snackbar-container-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
+    --mdc-snackbar-supporting-text-color: #fff;
+  }
 
-.warning-snackbar {
-  --mat-snack-bar-button-color: #fff;
-  --mdc-snackbar-container-color: rgb(245 158 11 / var(--tw-bg-opacity, 1));
-  --mdc-snackbar-supporting-text-color: #fff;
+  &.warning-snackbar {
+    --mat-snack-bar-button-color: #fff;
+    --mdc-snackbar-container-color: rgb(245 158 11 / var(--tw-bg-opacity, 1));
+    --mdc-snackbar-supporting-text-color: #fff;
+  }
+
+  &.soft-success-snackbar {
+    border-width: 1px;
+    border-color: rgb(22, 163, 74);
+    border-radius: 4px;
+    button {span {color: rgb(20, 83, 45)}}
+    --mdc-snackbar-container-color: rgb(240 253 244 / var(--tw-bg-opacity, 1));
+    --mdc-snackbar-supporting-text-color: rgb(21, 128, 61);   
+  }
+
+  &.soft-info-snackbar {
+    border-width: 1px;
+    border-color: rgb(37, 99, 235);
+    border-radius: 4px;
+    button {span {color: rgb(30, 58, 138)}}
+    --mdc-snackbar-container-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
+    --mdc-snackbar-supporting-text-color: rgb(29, 78, 216);   
+  }
+
+  &.soft-alert-snackbar {
+    border-width: 1px;
+    border-color: rgb(220, 38, 38);
+    border-radius: 4px;
+    button {span {color: rgb(127, 29, 29)}}
+    --mdc-snackbar-container-color: rgb(254, 242, 242);
+    --mdc-snackbar-supporting-text-color: rgb(185, 28, 28);   
+  }
+
+  &.soft-warning-snackbar {
+    border-width: 1px;
+    border-radius: 4px;
+    border-color: rgb(217, 119, 6);
+    button {span {color: rgb(120, 53, 15)}}
+    --mdc-snackbar-container-color: rgb(255 251 235 / var(--tw-bg-opacity, 1));
+    --mdc-snackbar-supporting-text-color: rgb(180, 83, 9);   
+  }
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,1 +1,24 @@
 // Styles from this file will override 'vendors.scss' and SEED's base styles.
+.success-snackbar  {
+  --mat-snack-bar-button-color: #fff;
+  --mdc-snackbar-container-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
+  --mdc-snackbar-supporting-text-color: #fff;
+}
+
+.info-snackbar {
+  --mat-snack-bar-button-color: #fff;
+  --mdc-snackbar-container-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  --mdc-snackbar-supporting-text-color: #fff;
+}
+
+.alert-snackbar {
+  --mat-snack-bar-button-color: #fff;
+  --mdc-snackbar-container-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
+  --mdc-snackbar-supporting-text-color: #fff;
+}
+
+.warning-snackbar {
+  --mat-snack-bar-button-color: #fff;
+  --mdc-snackbar-container-color: rgb(245 158 11 / var(--tw-bg-opacity, 1));
+  --mdc-snackbar-supporting-text-color: #fff;
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -26,37 +26,41 @@
 
   &.soft-success-snackbar {
     border-width: 1px;
-    border-color: rgb(22, 163, 74);
+    border-color: rgb(22 163 74);
     border-radius: 4px;
-    button {span {color: rgb(20, 83, 45)}}
+    button {span {color: rgb(20 83 45)}}
+
     --mdc-snackbar-container-color: rgb(240 253 244 / var(--tw-bg-opacity, 1));
-    --mdc-snackbar-supporting-text-color: rgb(21, 128, 61);   
+    --mdc-snackbar-supporting-text-color: rgb(21 128 61);   
   }
 
   &.soft-info-snackbar {
     border-width: 1px;
-    border-color: rgb(37, 99, 235);
+    border-color: rgb(37 99 235);
     border-radius: 4px;
-    button {span {color: rgb(30, 58, 138)}}
+    button {span {color: rgb(30 58 138)}}
+
     --mdc-snackbar-container-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
-    --mdc-snackbar-supporting-text-color: rgb(29, 78, 216);   
+    --mdc-snackbar-supporting-text-color: rgb(29 78 216);   
   }
 
   &.soft-alert-snackbar {
     border-width: 1px;
-    border-color: rgb(220, 38, 38);
+    border-color: rgb(220 38 38);
     border-radius: 4px;
-    button {span {color: rgb(127, 29, 29)}}
-    --mdc-snackbar-container-color: rgb(254, 242, 242);
-    --mdc-snackbar-supporting-text-color: rgb(185, 28, 28);   
+    button {span {color: rgb(127 29 29)}}
+
+    --mdc-snackbar-container-color: rgb(254 242 242);
+    --mdc-snackbar-supporting-text-color: rgb(185 28 28);   
   }
 
   &.soft-warning-snackbar {
     border-width: 1px;
     border-radius: 4px;
-    border-color: rgb(217, 119, 6);
-    button {span {color: rgb(120, 53, 15)}}
+    border-color: rgb(217 119 6);
+    button {span {color: rgb(120 53 15)}}
+
     --mdc-snackbar-container-color: rgb(255 251 235 / var(--tw-bg-opacity, 1));
-    --mdc-snackbar-supporting-text-color: rgb(180, 83, 9);   
+    --mdc-snackbar-supporting-text-color: rgb(180 83 9);   
   }
 }


### PR DESCRIPTION
Include four snackbar color options in two variants soft and fill.  Color are same as fuse fill colors visible here: https://angular-material.fusetheme.com/ui/fuse-components/components/alert

Snackbars can be fired off from components by injecting the `MatSnackBar` service and then doing something like this;

```
this._snackBar.open('Selection Successful', 'OK',
 { panelClass: 'soft-info-snackbar', horizontalPosition: 'center', verticalPosition: 'top' }
)

```
Soft:

![image](https://github.com/user-attachments/assets/ee923859-3d08-45ca-a470-3a46976c1121)
![image](https://github.com/user-attachments/assets/d2f6d593-d038-4902-a0ba-72f6654e2bb8)
![image](https://github.com/user-attachments/assets/c8702d90-3666-4eb0-b214-f1d92d414319)
![image](https://github.com/user-attachments/assets/68e1ef30-5a23-486f-bd6a-b0c9b24f7a15)

Fill:
![image](https://github.com/user-attachments/assets/ac3dcbff-0d35-42c7-b781-9649291bff6e)
![image](https://github.com/user-attachments/assets/133ebf67-fe7f-4743-837c-21bf637b194b)
![image](https://github.com/user-attachments/assets/926521a3-491c-4f81-96fc-4539d2d41dc1)
![image](https://github.com/user-attachments/assets/bdfbe824-d3f3-455a-9ba4-c124554dbdd0)
