### PR TITLE
Audit Template Settings

### DIFF
--- a/src/@seed/api/audit-template/audit-template.service.ts
+++ b/src/@seed/api/audit-template/audit-template.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core'
+import { ReplaySubject } from 'rxjs'
+import type { AuditTemplateReportType } from './audit-template.types'
+
+@Injectable({ providedIn: 'root' })
+export class AuditTemplateService {
+  private _reportTypes = new ReplaySubject<AuditTemplateReportType[]>(1)
+  reportTypes$ = this._reportTypes.asObservable()
+
+  constructor() {
+    this._reportTypes.next([
+      { name: 'ASHRAE Level 2 Report' },
+      { name: 'Atlanta Report' },
+      { name: 'Baltimore Energy Audit Report' },
+      { name: 'Berkeley Report' },
+      { name: 'BRICR Phase 0/1' },
+      { name: 'Brisbane Energy Audit Report' },
+      { name: 'DC BEPS Energy Audit Report' },
+      { name: 'DC BEPS RCx Report' },
+      { name: 'Demo City Report' },
+      { name: 'Denver Energy Audit Report' },
+      { name: 'EE-RLF Template' },
+      { name: 'Energy Trust of Oregon Report' },
+      { name: 'Los Angeles Report' },
+      { name: 'Minneapolis Energy Evaluation Report' },
+      { name: 'New York City Energy Efficiency Report' },
+      { name: 'Office of Recapitalization Energy Audit Report' },
+      { name: 'Open Efficiency Report' },
+      { name: 'San Francisco Report' },
+      { name: 'St. Louis RCx Report' },
+      { name: 'St. Louis Report' },
+      { name: 'WA Commerce Clean Buildings - Form D Report' },
+      { name: 'WA Commerce Grants Report' },
+    ])
+  }
+}

--- a/src/@seed/api/audit-template/audit-template.types.ts
+++ b/src/@seed/api/audit-template/audit-template.types.ts
@@ -1,0 +1,3 @@
+export type AuditTemplateReportType = {
+  name: string;
+}

--- a/src/@seed/api/audit-template/index.ts
+++ b/src/@seed/api/audit-template/index.ts
@@ -1,0 +1,2 @@
+export * from './audit-template.service'
+export * from './audit-template.types'

--- a/src/app/modules/organizations/settings/audit-template/audit-template.component.html
+++ b/src/app/modules/organizations/settings/audit-template/audit-template.component.html
@@ -1,10 +1,125 @@
-<h3 class="text-2xl font-bold">Audit Template Settings</h3>
-<div class="prose">
-  If your organization has configured a customized report form in Audit Template, fill out the settings below to enable importing Audit
-  Template submissions into your SEED organization.
-</div>
-<div class="prose">
-  @if (organization$ | async; as o) {
-    Organization API Key: {{ o.name }}
+<seed-page [config]="{ title: 'Organization Settings: Audit Template' }" title="Organization Settings: Audit Template">
+
+  @if (organization) {
+    <div class="flex-auto p-6 sm:p-10" *transloco="let t">
+      <div class="prose">
+        If your organization has configured a customized report form in Audit Template, 
+        fill out the settings below to enable importing Audit Template submissions into
+        your SEED organization.
+      </div>
+      <div class="max-w-2xl">
+        <form
+          class="bg-card flex flex-col overflow-hidden rounded-2xl p-2 pb-4 shadow"
+          [formGroup]="auditTemplateForm"
+          (ngSubmit)="submit()"
+        >
+          <div class="flex flex-col">
+            <div class="text-lg font-medium">Audit Template Credentials</div>
+            <div class="prose mb-6 text-secondary">
+              <p>An API Token, Username and Password are all required to connect to your Audit Template.</p>
+              <p>Please refer to the <a class="text-blue-400" href="https://staging.labworks.org/reports/api/" target="_new">Audit Template documentation</a> for more information.</p>
+            </div>
+            <mat-form-field class="mb-6">
+              <mat-label>Audit Template Organization Token</mat-label>
+              <input matInput [formControlName]="'at_organization_token'" />
+              <mat-hint>
+                Note, do not prefix the token with "Token ", only include the token itself.
+              </mat-hint>
+            </mat-form-field>
+            <mat-form-field class="mb-6">
+              <mat-label>Audit Template Email</mat-label>
+              <input matInput [formControlName]="'audit_template_user'" />
+              <mat-hint>
+                Use the email associated with your account from the <a class="text-blue-400" href="https://staging.labworks.org/">Building Energy Score Site</a>.
+              </mat-hint>
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>Audit Template Password
+              </mat-label>
+              <input matInput [formControlName]="'audit_template_password'" [type]="passwordHidden ? 'password' : 'text'" />
+              <button mat-icon-button matSuffix type="button" (click)="togglePassword()" [attr.aria-label]="'Hide password'" [attr.aria-pressed]="passwordHidden">
+                <mat-icon class="icon-size-5" [svgIcon]="passwordHidden ? 'fa-solid:eye-slash' : 'fa-solid:eye'"></mat-icon>
+              </button>
+              <mat-hint>
+                Use the password associated with your account from the <a class="text-blue-400" href="https://staging.labworks.org/">Building Energy Score Site</a>.
+              </mat-hint>
+            </mat-form-field>
+    
+          </div>
+          <mat-divider role="separator" class="mat-divider mb-6 mt-4 mat-divider-horizontal" aria-orientation="horizontal"></mat-divider>
+          <div class="flex flex-col">
+            <div class="text-lg font-medium">{{ t('Audit Template City ID') }}</div>
+            <div class="prose mb-6 text-secondary">
+              <p>Specify your Audit Template City ID. This number is visible in the Audit Template URL when browsing to the 'CITIES' tab. SEED will import submission data for the specified City only.
+
+              </p>
+            </div>
+            <mat-form-field class="mb-6">
+              <mat-label>{{ t('Audit Template City ID') }}</mat-label>
+              <input matInput [formControlName]="'audit_template_city_id'" type="number" />
+            </mat-form-field>
+          </div>
+          <mat-divider role="separator" class="mat-divider mb-6 mt-4 mat-divider-horizontal" aria-orientation="horizontal"></mat-divider>
+          <div class="flex flex-col">
+            <div class="text-lg font-medium">{{ t('Audit Template Submission Status') }}</div>
+            <div class="prose mb-6 text-secondary">
+              <p>SEED will import data for submissions with the following statuses in Audit Template.
+              </p>
+            </div>
+            <div class="flex flex-row">
+              <mat-checkbox formControlName="status_complies">Complies</mat-checkbox>
+              <mat-checkbox formControlName="status_pending">Pending</mat-checkbox>
+              <mat-checkbox formControlName="status_received">Received</mat-checkbox>
+              <mat-checkbox formControlName="status_rejected">Rejected</mat-checkbox>
+            </div>
+          </div>
+          <mat-divider role="separator" class="mat-divider mb-6 mt-4 mat-divider-horizontal" aria-orientation="horizontal"></mat-divider>
+          <div class="flex flex-col">
+            <div class="text-lg font-medium">{{ t('Conditional Import') }}</div>
+            <div class="prose mb-6 text-secondary">
+              <p>When this checkbox is checked, SEED will only import Audit Template submissions that have been submitted more recently than the SEED records' most recent update. If unchecked, all Audit Template submissions will be imported regardless of the submission date.
+              </p>
+            </div>
+            <div class="flex flex-row">
+              <mat-slide-toggle formControlName="audit_template_conditional_import">{{ t('Enable Conditional Import') }}</mat-slide-toggle>
+            </div>
+            <div class="my-6">
+              <button  mat-flat-button color="accent" type="button" (click)="importSubmissions()" [attr.aria-label]="'Import Submissions'">
+                Import Submissions
+              </button>
+            </div>
+          </div>
+          <mat-divider role="separator" class="mat-divider mb-6 mt-4 mat-divider-horizontal" aria-orientation="horizontal"></mat-divider>
+          <div class="flex flex-col">
+            <div class="text-lg font-medium">{{ t('Schedule Weekly Update') }}</div>
+
+            <div class="flex flex-row">
+              <mat-slide-toggle formControlName="audit_template_sync_enabled">{{ t('Enable Audit Template Auto Sync') }}</mat-slide-toggle>
+            </div>
+          </div>
+          <mat-divider role="separator" class="mat-divider mb-6 mt-4 mat-divider-horizontal" aria-orientation="horizontal"></mat-divider>
+          <div class="flex flex-col">
+            <div class="text-lg font-medium">{{ t('Advanced Settings') }}</div>
+            <div class="prose mb-6 text-secondary">
+              <p>{{ t('If you wish to generate stub Audit Template reports from SEED data, select which Audit Template Report Type SEED should generate.') }}</p>
+            </div>
+
+            <mat-form-field class="mb-6">
+              <mat-label>{{ t('Audit Template Report Type') }}</mat-label>
+              <mat-select formControlName="audit_template_report_type">
+                <mat-option value="">None</mat-option>
+                @for (atrt of auditTemplateReportTypes; track atrt.name) {
+                  <mat-option [value]="atrt.name">{{ t(atrt.name) }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          </div>
+          <div>
+            <button mat-flat-button [disabled]="auditTemplateForm.invalid || auditTemplateForm.pending" color="primary">
+              <span class="">{{ t('Save Changes') }}</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
   }
-</div>

--- a/src/app/modules/organizations/settings/audit-template/audit-template.component.ts
+++ b/src/app/modules/organizations/settings/audit-template/audit-template.component.ts
@@ -1,15 +1,113 @@
 import { CommonModule } from '@angular/common'
+import { type OnDestroy, type OnInit } from '@angular/core'
 import { Component, inject } from '@angular/core'
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms'
+import { MatButton } from '@angular/material/button'
+import { MatCheckbox } from '@angular/material/checkbox'
+import { MatDivider } from '@angular/material/divider'
+import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatIconModule } from '@angular/material/icon'
-import { OrganizationService } from '@seed/api/organization'
+import { MatInputModule } from '@angular/material/input'
+import { MatSelectModule } from '@angular/material/select'
+import { MatSlideToggleModule } from '@angular/material/slide-toggle'
+import { Subject, takeUntil } from 'rxjs'
+import { type AuditTemplateReportType, AuditTemplateService } from '@seed/api/audit-template'
+import { type Organization, OrganizationService } from '@seed/api/organization'
+import { PageComponent } from '@seed/components'
 import { SharedImports } from '@seed/directives'
+import { SnackbarService } from 'app/core/snackbar/snackbar.service'
 
 @Component({
   selector: 'seed-organizations-settings-audit-template',
   templateUrl: './audit-template.component.html',
-  imports: [CommonModule, SharedImports, MatIconModule],
+  imports: [
+    CommonModule,
+    SharedImports,
+    MatButton,
+    MatCheckbox,
+    MatDivider,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSelectModule,
+    MatSlideToggleModule,
+    ReactiveFormsModule,
+    PageComponent],
 })
-export class AuditTemplateComponent {
+export class AuditTemplateComponent implements OnDestroy, OnInit {
   private _organizationService = inject(OrganizationService)
-  organization$ = this._organizationService.currentOrganization$
+  private _auditTemplateService = inject(AuditTemplateService)
+  private _snackBar = inject(SnackbarService)
+  private readonly _unsubscribeAll$ = new Subject<void>()
+  organization: Organization
+  auditTemplateReportTypes: AuditTemplateReportType[]
+  auditTemplateForm = new FormGroup({
+    at_organization_token: new FormControl(''),
+    audit_template_user: new FormControl('', [Validators.email]),
+    audit_template_password: new FormControl(''),
+    audit_template_city_id: new FormControl(),
+    status_complies: new FormControl(false),
+    status_pending: new FormControl(false),
+    status_received: new FormControl(false),
+    status_rejected: new FormControl(false),
+    audit_template_conditional_import: new FormControl(false),
+    audit_template_sync_enabled: new FormControl(false),
+    audit_template_report_type: new FormControl(''),
+  })
+  status_fields = [
+    { key: 'Complies', field: 'status_complies' },
+    { key: 'Pending', field: 'status_pending' },
+    { key: 'Received', field: 'status_received' },
+    { key: 'Rejected', field: 'status_rejected' },
+  ]
+  passwordHidden = true
+
+  ngOnInit(): void {
+    this._organizationService.currentOrganization$.pipe(takeUntil(this._unsubscribeAll$)).subscribe((organization) => {
+      this.organization = organization
+      this.auditTemplateForm.get('at_organization_token').setValue(this.organization.at_organization_token)
+      this.auditTemplateForm.get('audit_template_user').setValue(this.organization.audit_template_user)
+      this.auditTemplateForm.get('audit_template_city_id').setValue(this.organization.audit_template_city_id)
+      this.auditTemplateForm.get('audit_template_password').setValue(this.organization.audit_template_password)
+      this.auditTemplateForm.get('audit_template_sync_enabled').setValue(this.organization.audit_template_sync_enabled)
+      this.auditTemplateForm.get('audit_template_report_type').setValue(this.organization.audit_template_report_type)
+      this.auditTemplateForm.get('audit_template_conditional_import').setValue(this.organization.audit_template_conditional_import)
+      for (const field of this.status_fields) {
+        this.auditTemplateForm.get(field.field).setValue(this.organization.audit_template_status_types.includes(field.key))
+      }
+    })
+    this._auditTemplateService.reportTypes$.pipe(takeUntil(this._unsubscribeAll$)).subscribe((types) => {
+      this.auditTemplateReportTypes = types
+    })
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribeAll$.next()
+    this._unsubscribeAll$.complete()
+  }
+
+  togglePassword(): void {
+    this.passwordHidden = !this.passwordHidden
+  }
+
+  importSubmissions(): void {
+    // TODO - Build out import wizard
+    console.log('Not implemented')
+    this._snackBar.warning('Not implemented')
+  }
+
+  submit(): void {
+    if (this.auditTemplateForm.valid) {
+      this.organization.at_organization_token = this.auditTemplateForm.get('at_organization_token').value
+      this.organization.audit_template_user = this.auditTemplateForm.get('audit_template_user').value
+      this.organization.audit_template_city_id = this.auditTemplateForm.get('audit_template_city_id').value as number
+      this.organization.audit_template_password = this.auditTemplateForm.get('audit_template_password').value
+      this.organization.audit_template_sync_enabled = this.auditTemplateForm.get('audit_template_sync_enabled').value
+      this.organization.audit_template_report_type = this.auditTemplateForm.get('audit_template_report_type').value
+      this.organization.audit_template_conditional_import = this.auditTemplateForm.get('audit_template_conditional_import').value
+
+      this.organization.audit_template_status_types = this.status_fields.filter((f) => this.auditTemplateForm.get(f.field).value === true).map((f) => f.key).join(',')
+      this._organizationService.updateSettings(this.organization).subscribe()
+    }
+  }
 }

--- a/src/app/modules/organizations/settings/settings.component.html
+++ b/src/app/modules/organizations/settings/settings.component.html
@@ -1,7 +1,7 @@
 <mat-drawer-container class="h-full">
-  <mat-drawer mode="side" opened>
+  <mat-drawer mode="side" opened class="h-lvh">
     <seed-vertical-navigation
-      class="bg-gray-100 dark:bg-gray-700 print:hidden"
+      class="bg-gray-100 dark:bg-gray-700 mt-4 print:hidden"
       [appearance]="'default'"
       [mode]="'side'"
       name="settingsNavigation"


### PR DESCRIPTION
Does not include the import submissions flow.  Added to the spreadsheet.

Otherwise implements the audit template settings page.  Includes service with report types hardcoded for now until we figure out how to lean on the audit template api to get them.