### PR TITLE
Various UI Consistency Fixes

### DIFF
--- a/src/@seed/api/analysis/analysis.types.ts
+++ b/src/@seed/api/analysis/analysis.types.ts
@@ -116,6 +116,7 @@ export type AnalysisSummary = {
   number_extra_data_fields: number;
   status: string;
   total_records: number;
+  total_sqft: number;
 }
 
 export type AnalysisSummaryStats = {

--- a/src/@seed/api/filter-group/filter-group.service.ts
+++ b/src/@seed/api/filter-group/filter-group.service.ts
@@ -6,7 +6,13 @@ import { catchError, map, ReplaySubject, take, tap } from 'rxjs'
 import { ErrorService } from '@seed/services'
 import { naturalSort } from '@seed/utils'
 import { UserService } from '../user'
-import type { FilterGroup, FilterGroupInventoryType, FilterGroupResponse, FilterGroupsResponse, FilterGroupUpsertPayload } from './filter-group.types'
+import type {
+  FilterGroup,
+  FilterGroupInventoryType,
+  FilterGroupResponse,
+  FilterGroupsResponse,
+  FilterGroupUpsertPayload,
+} from './filter-group.types'
 
 @Injectable({ providedIn: 'root' })
 export class FilterGroupService {

--- a/src/@seed/components/column-profiles/column-profiles.component.html
+++ b/src/@seed/components/column-profiles/column-profiles.component.html
@@ -13,24 +13,23 @@
         }
       </mat-select>
     </div>
-    <a class="flex" (click)="openProfileModal('create')" mat-stroked-button matTooltip="Create New Profile">
-      <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:folder-plus"></mat-icon>
-    </a>
-    <a class="flex" [disabled]="!currentProfile" (click)="openProfileModal('rename')" mat-stroked-button matTooltip="Rename this Profile">
-      <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:eraser"></mat-icon>
-    </a>
-    <a class="flex" [disabled]="!currentProfile" (click)="openDeleteModal()" mat-stroked-button matTooltip="Delete this Profile">
-      <mat-icon class="fill-red-700 icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-    </a>
-    <a
-      class="flex"
+    <button (click)="openProfileModal('create')" mat-icon-button matTooltip="Create New Profile">
+      <mat-icon class="scale-75 fill-primary-700" svgIcon="fa-solid:plus"></mat-icon>
+    </button>
+    <button [disabled]="!currentProfile" (click)="openProfileModal('rename')" mat-icon-button matTooltip="Rename this Profile">
+      <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+    </button>
+    <button [disabled]="!currentProfile" (click)="openDeleteModal()" mat-icon-button matTooltip="Delete this Profile">
+      <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+    </button>
+    <button
       [disabled]="!currentProfile"
       (click)="openProfileModal('create', currentProfile.columns)"
-      mat-stroked-button
+      mat-icon-button
       matTooltip="Copy This Profile"
     >
-      <mat-icon class="fill-cyan-600 icon-size-4" svgIcon="fa-solid:copy"></mat-icon>
-    </a>
+      <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:copy"></mat-icon>
+    </button>
   </div>
 
   @if (rowData.length) {

--- a/src/app/modules/datasets/data-mappings/step1/map-data.component.html
+++ b/src/app/modules/datasets/data-mappings/step1/map-data.component.html
@@ -17,15 +17,15 @@
       }
     </mat-select>
     <!-- Profile Controls -->
-    <a class="flex" [disabled]="!profile" (click)="applyProfile()" matTooltip="Apply Profile" mat-stroked-button>
-      <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:check"></mat-icon>
-    </a>
-    <a class="flex" [disabled]="!profile" (click)="saveProfile()" matTooltip="Save Profile" mat-stroked-button>
-      <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:floppy-disk"></mat-icon>
-    </a>
-    <a class="flex" (click)="createProfile()" matTooltip="Create Profile" mat-stroked-button>
-      <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:plus"></mat-icon>
-    </a>
+    <button [disabled]="!profile" (click)="applyProfile()" matTooltip="Apply Profile" mat-icon-button>
+      <mat-icon class="scale-75 fill-primary-700" svgIcon="fa-solid:check"></mat-icon>
+    </button>
+    <button [disabled]="!profile" (click)="saveProfile()" matTooltip="Save Profile" mat-icon-button>
+      <mat-icon class="scale-75 fill-green-700" svgIcon="fa-solid:floppy-disk"></mat-icon>
+    </button>
+    <button (click)="createProfile()" matTooltip="Create Profile" mat-icon-button>
+      <mat-icon class="scale-75 fill-primary-700" svgIcon="fa-solid:plus"></mat-icon>
+    </button>
   </div>
 </div>
 

--- a/src/app/modules/datasets/datasets.component.ts
+++ b/src/app/modules/datasets/datasets.component.ts
@@ -102,8 +102,8 @@ export class DatasetsComponent implements OnDestroy, OnInit {
         <span class="material-icons text-base">add</span>
         <span class="text-sm">Meter Data</span>
       </span>
-      <span class="material-icons cursor-pointer text-secondary my-auto" title="Rename Dataset" data-action="rename">edit</span>
-      <span class="material-icons cursor-pointer text-secondary my-auto" title="Delete Dataset" data-action="delete">clear</span>
+      <span class="material-icons cursor-pointer text-cyan-600 my-auto" title="Rename Dataset" data-action="rename">edit</span>
+      <span class="material-icons cursor-pointer text-red-500 my-auto" title="Delete Dataset" data-action="delete">delete</span>
       </div>
     `
   }

--- a/src/app/modules/insights/custom-reports/custom-reports.component.html
+++ b/src/app/modules/insights/custom-reports/custom-reports.component.html
@@ -27,11 +27,6 @@
             @if (selectedReport) {
               <div class="flex items-center gap-2 rounded bg-primary-200 px-3 py-1.5 dark:bg-primary-700">
                 <span class="flex-1 truncate">{{ selectedReport.name }}</span>
-                @if (auth.requires_member) {
-                  <button class="!size-6 !min-w-0" (click)="clickDelete(selectedReport)" mat-icon-button>
-                    <mat-icon class="!text-base" fontIcon="close" />
-                  </button>
-                }
               </div>
             }
 
@@ -42,11 +37,6 @@
                     <a class="text-default flex-1 truncate no-underline" [routerLink]="['/insights/custom-reports', report.id]">
                       {{ report.name }}
                     </a>
-                    @if (auth.requires_member) {
-                      <button class="!size-6 !min-w-0" (click)="clickDelete(report); $event.stopPropagation()" mat-icon-button>
-                        <mat-icon class="!text-base" fontIcon="close" />
-                      </button>
-                    }
                   </div>
                 }
               }
@@ -268,13 +258,13 @@
                 <div class="text-secondary font-semibold">Actions</div>
 
                 @if (!editing && selectedReport) {
-                  <div class="flex gap-2">
-                    <a class="mr-2" (click)="clickEdit()" mat-stroked-button>
-                      <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil"></mat-icon>
-                    </a>
-                    <a (click)="clickDelete(selectedReport)" mat-stroked-button color="warn">
-                      <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-                    </a>
+                  <div class="flex gap-1">
+                    <button (click)="clickEdit()" mat-icon-button matTooltip="Edit">
+                      <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil" />
+                    </button>
+                    <button (click)="clickDelete(selectedReport)" mat-icon-button matTooltip="Delete">
+                      <mat-icon class="scale-75 text-red-500" svgIcon="fa-solid:trash" />
+                    </button>
                   </div>
                 }
 

--- a/src/app/modules/insights/default-reports/default-reports.component.html
+++ b/src/app/modules/insights/default-reports/default-reports.component.html
@@ -23,7 +23,7 @@
             title="Save"
             aria-label="Save"
           >
-            <mat-icon class="scale-75" svgIcon="fa-solid:floppy-disk"></mat-icon>
+            <mat-icon class="scale-75 text-green-600" svgIcon="fa-solid:floppy-disk"></mat-icon>
           </button>
           <button
             [disabled]="!currentConfig || currentConfig.id === null"
@@ -32,7 +32,7 @@
             title="Rename"
             aria-label="Rename"
           >
-            <mat-icon class="scale-75" svgIcon="fa-solid:pen"></mat-icon>
+            <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
           </button>
           <button
             [disabled]="!currentConfig || currentConfig.id === null"
@@ -44,7 +44,7 @@
             <mat-icon class="scale-75 text-red-500" svgIcon="fa-solid:trash"></mat-icon>
           </button>
           <button (click)="newConfig()" mat-icon-button title="New" aria-label="New">
-            <mat-icon class="scale-75" svgIcon="fa-solid:plus"></mat-icon>
+            <mat-icon class="scale-75 fill-primary-700" svgIcon="fa-solid:plus"></mat-icon>
           </button>
         </div>
       }

--- a/src/app/modules/insights/property-insights/property-insights.component.html
+++ b/src/app/modules/insights/property-insights/property-insights.component.html
@@ -28,7 +28,7 @@
         <div>
           <div class="flex flex-col">
             <mat-button-toggle-group
-              class="border-button-toggle-group compact-button-toggle-group strike-through"
+              class="compact-button-toggle-group strike-through"
               [value]="datasetVisibility"
               [disabled]="!program"
               multiple

--- a/src/app/modules/inventory-list/list/grid/filter-group/filter-group-modal.component.ts
+++ b/src/app/modules/inventory-list/list/grid/filter-group/filter-group-modal.component.ts
@@ -24,9 +24,12 @@ export class FilterGroupModalComponent {
 
   get title(): string {
     switch (this.data.action) {
-      case 'new': return 'New Filter Group'
-      case 'rename': return 'Rename Filter Group'
-      case 'delete': return 'Delete Filter Group'
+      case 'new':
+        return 'New Filter Group'
+      case 'rename':
+        return 'Rename Filter Group'
+      case 'delete':
+        return 'Delete Filter Group'
     }
   }
 

--- a/src/app/modules/inventory-list/list/grid/filter-group/filter-group-selector.component.html
+++ b/src/app/modules/inventory-list/list/grid/filter-group/filter-group-selector.component.html
@@ -1,6 +1,6 @@
 <div class="relative mr-1 flex flex-col">
   <mat-label class="text-secondary text-sm">Filter Group</mat-label>
-  <div class="flex h-6 items-center gap-1">
+  <div class="flex h-8 items-center gap-1">
     <mat-select
       class="h-6 w-50 rounded border border-gray-500 p-3 text-sm"
       [(value)]="selectedFilterGroupId"
@@ -19,28 +19,28 @@
 
     @if (isAliRoot) {
       <button
-        class="!size-6 !min-w-0"
+        class="!size-8 !min-w-0"
         [disabled]="!selectedFilterGroup || !modified"
         (click)="saveFilterGroup()"
         mat-icon-button
         matTooltip="Save"
       >
-        <mat-icon class="text-green-600 icon-size-5" fontIcon="save" />
+        <mat-icon class="scale-75 text-green-600" svgIcon="fa-solid:floppy-disk" />
       </button>
-      <button class="!size-6 !min-w-0" [disabled]="!selectedFilterGroup" (click)="renameFilterGroup()" mat-icon-button matTooltip="Rename">
-        <mat-icon class="icon-size-5" svgIcon="fa-solid:pencil" />
+      <button class="!size-8 !min-w-0" [disabled]="!selectedFilterGroup" (click)="renameFilterGroup()" mat-icon-button matTooltip="Rename">
+        <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil" />
       </button>
-      <button class="!size-6 !min-w-0" [disabled]="!selectedFilterGroup" (click)="deleteFilterGroup()" mat-icon-button matTooltip="Delete">
-        <mat-icon class="text-warn icon-size-5" svgIcon="fa-solid:x" />
+      <button class="!size-8 !min-w-0" [disabled]="!selectedFilterGroup" (click)="deleteFilterGroup()" mat-icon-button matTooltip="Delete">
+        <mat-icon class="scale-75 text-red-500" svgIcon="fa-solid:trash" />
       </button>
-      <button class="!size-6 !min-w-0" (click)="newFilterGroup()" mat-icon-button matTooltip="New Filter Group">
-        <mat-icon class="icon-size-5" fontIcon="add" />
+      <button class="!size-8 !min-w-0" (click)="newFilterGroup()" mat-icon-button matTooltip="New Filter Group">
+        <mat-icon class="scale-75 fill-primary-700" svgIcon="fa-solid:plus" />
       </button>
     }
 
     <!-- Label toggle -->
-    <button class="!size-6 !min-w-0" (click)="showLabelPanel = !showLabelPanel" mat-icon-button matTooltip="Labels">
-      <mat-icon class="!text-blue-600 icon-size-5" [class.!text-blue-800]="hasLabelSelections" fontIcon="label" />
+    <button class="!size-8 !min-w-0" (click)="showLabelPanel = !showLabelPanel" mat-icon-button matTooltip="Labels">
+      <mat-icon class="!text-blue-600" [class.!text-blue-800]="hasLabelSelections" fontIcon="label" />
     </button>
   </div>
 

--- a/src/app/modules/inventory-list/list/grid/filter-group/filter-group-selector.component.ts
+++ b/src/app/modules/inventory-list/list/grid/filter-group/filter-group-selector.component.ts
@@ -286,9 +286,12 @@ export class FilterGroupSelectorComponent implements OnDestroy, OnInit {
 
   private _getLabelList(operator: 'and' | 'or' | 'exclude'): number[] {
     switch (operator) {
-      case 'and': return this.andLabels
-      case 'or': return this.orLabels
-      case 'exclude': return this.excludeLabels
+      case 'and':
+        return this.andLabels
+      case 'or':
+        return this.orLabels
+      case 'exclude':
+        return this.excludeLabels
     }
   }
 

--- a/src/app/modules/inventory-list/list/inventory.component.ts
+++ b/src/app/modules/inventory-list/list/inventory.component.ts
@@ -18,14 +18,28 @@ import type {
   Profile,
   State,
 } from 'app/modules/inventory'
-import { ActionsComponent, ConfigSelectorComponent, FilterGroupSelectorComponent, FilterSortChipsComponent, InventoryGridComponent } from './grid'
+import {
+  ActionsComponent,
+  ConfigSelectorComponent,
+  FilterGroupSelectorComponent,
+  FilterSortChipsComponent,
+  InventoryGridComponent,
+} from './grid'
 import type { LabelSelections } from './grid/filter-group/filter-group-selector.component'
 
 @Component({
   selector: 'seed-inventory',
   templateUrl: './inventory.component.html',
   encapsulation: ViewEncapsulation.None,
-  imports: [ActionsComponent, ConfigSelectorComponent, FilterGroupSelectorComponent, FilterSortChipsComponent, InventoryGridComponent, PageComponent, SharedImports],
+  imports: [
+    ActionsComponent,
+    ConfigSelectorComponent,
+    FilterGroupSelectorComponent,
+    FilterSortChipsComponent,
+    InventoryGridComponent,
+    PageComponent,
+    SharedImports,
+  ],
 })
 export class InventoryComponent implements OnDestroy, OnInit {
   private _activatedRoute = inject(ActivatedRoute)
@@ -85,7 +99,9 @@ export class InventoryComponent implements OnDestroy, OnInit {
         switchMap((orgId) => this.getDependencies(orgId)),
         map((results) => this.setDependencies(results)),
         switchMap((profile_id) => this.getProfile(profile_id)),
-        tap(() => { this._fetchAppliedLabels() }),
+        tap(() => {
+          this._fetchAppliedLabels()
+        }),
         switchMap(() => this.loadInventory()),
         tap(() => {
           this.setFilterSorts()
@@ -367,17 +383,23 @@ export class InventoryComponent implements OnDestroy, OnInit {
   }
 
   get filterGroupInventoryType() {
-    return this.type === 'taxlots' ? 'Tax Lot' as const : 'Property' as const
+    return this.type === 'taxlots' ? ('Tax Lot' as const) : ('Property' as const)
   }
 
   onFilterGroupApplied(fg: { query_dict?: Record<string, unknown> } | null): void {
     // Sync filter group's query_dict into userSettings so loadInventory uses consistent filters
     if (fg?.query_dict) {
-      this.userSettings = { ...this.userSettings, filters: { ...this.userSettings.filters, [this.type]: fg.query_dict as Record<string, Record<string, unknown>> } }
+      this.userSettings = {
+        ...this.userSettings,
+        filters: { ...this.userSettings.filters, [this.type]: fg.query_dict as Record<string, Record<string, unknown>> },
+      }
     } else {
       // When deselecting a filter group, preserve whatever filters the grid currently has
       const currentGridFilters = this.gridApi?.getFilterModel() ?? {}
-      this.userSettings = { ...this.userSettings, filters: { ...this.userSettings.filters, [this.type]: currentGridFilters as Record<string, Record<string, unknown>> } }
+      this.userSettings = {
+        ...this.userSettings,
+        filters: { ...this.userSettings.filters, [this.type]: currentGridFilters as Record<string, Record<string, unknown>> },
+      }
     }
     this.page = 1
     // Don't call loadInventory here — labelSelectionsChanged always fires right after

--- a/src/app/modules/inventory-list/summary/summary.component.html
+++ b/src/app/modules/inventory-list/summary/summary.component.html
@@ -30,6 +30,10 @@
             <div class="text-secondary ml-4 w-40">Extra Data Fields:</div>
             <div>{{ totalExtraData }}</div>
           </div>
+          <div class="flex">
+            <div class="text-secondary ml-4 w-40">Total Square Feet:</div>
+            <div>{{ totalSqft }}</div>
+          </div>
         </div>
       }
     </div>

--- a/src/app/modules/inventory-list/summary/summary.component.ts
+++ b/src/app/modules/inventory-list/summary/summary.component.ts
@@ -40,6 +40,7 @@ export class SummaryComponent implements OnDestroy, OnInit {
   type = this._route.snapshot.paramMap.get('type') as InventoryType
   totalRecords: string
   totalExtraData: string
+  totalSqft: string
 
   ngOnInit() {
     this.initPage().pipe(takeUntil(this._unsubscribeAll$)).subscribe()
@@ -66,6 +67,7 @@ export class SummaryComponent implements OnDestroy, OnInit {
       tap((summary) => {
         this.totalRecords = summary.total_records.toLocaleString()
         this.totalExtraData = summary.number_extra_data_fields.toLocaleString()
+        this.totalSqft = (summary.total_sqft ?? 0).toLocaleString()
         this.summary = summary
       }),
       catchError(() => {

--- a/src/app/modules/organizations/columns/geocoding/geocoding.component.html
+++ b/src/app/modules/organizations/columns/geocoding/geocoding.component.html
@@ -17,9 +17,9 @@
         <div>{{ column.display_name }}</div>
       </div>
       <div class="ml-auto flex">
-        <a (click)="delete(column)" mat-stroked-button
-          ><mat-icon class="icon-size-4" svgIcon="fa-solid:x" matTooltip="Remove from geocoding"></mat-icon
-        ></a>
+        <button (click)="delete(column)" mat-icon-button
+          ><mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash" matTooltip="Remove from geocoding"></mat-icon
+        ></button>
       </div>
     </div>
   }
@@ -36,7 +36,7 @@
     </mat-select>
   </mat-form-field>
   <div>
-    <button [disabled]="addForm.invalid || addForm.pending" mat-flat-button color="accent">
+    <button [disabled]="addForm.invalid || addForm.pending" mat-stroked-button>
       <span class="">Add Geocoding Column</span>
     </button>
   </div>

--- a/src/app/modules/organizations/columns/geocoding/geocoding.component.html
+++ b/src/app/modules/organizations/columns/geocoding/geocoding.component.html
@@ -17,9 +17,9 @@
         <div>{{ column.display_name }}</div>
       </div>
       <div class="ml-auto flex">
-        <button (click)="delete(column)" mat-icon-button
-          ><mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash" matTooltip="Remove from geocoding"></mat-icon
-        ></button>
+        <button (click)="delete(column)" mat-icon-button>
+          <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash" matTooltip="Remove from geocoding"></mat-icon>
+        </button>
       </div>
     </div>
   }

--- a/src/app/modules/organizations/columns/import-settings/import-settings.component.html
+++ b/src/app/modules/organizations/columns/import-settings/import-settings.component.html
@@ -11,9 +11,9 @@
         <li class="space-between align-items-center my-4 flex w-1/2 flex-row border-b-2 py-2">
           <div class="flex self-center">{{ c.display_name }}</div>
           <div class="ml-auto flex justify-self-end">
-            <a (click)="removeExcluded(c)" mat-stroked-button color="warn">
-              <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-            </a>
+            <button (click)="removeExcluded(c)" mat-icon-button>
+              <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+            </button>
           </div>
         </li>
       }
@@ -29,7 +29,7 @@
           </mat-select>
         </mat-form-field>
         <div>
-          <button [disabled]="addExcludeForm.invalid || addExcludeForm.pending" mat-flat-button color="accent">
+          <button [disabled]="addExcludeForm.invalid || addExcludeForm.pending" mat-stroked-button>
             <span class="">Exclude Column</span>
           </button>
         </div>
@@ -48,9 +48,9 @@
         <li class="space-between align-items-center my-4 flex w-1/2 flex-row border-b-2 py-2">
           <div class="flex self-center">{{ c.display_name }}</div>
           <div class="ml-auto flex justify-self-end">
-            <a (click)="removeEmpty(c)" mat-stroked-button color="warn">
-              <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-            </a>
+            <button (click)="removeEmpty(c)" mat-icon-button>
+              <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+            </button>
           </div>
         </li>
       }
@@ -66,7 +66,7 @@
           </mat-select>
         </mat-form-field>
         <div>
-          <button [disabled]="addEmptyForm.invalid || addEmptyForm.pending" mat-flat-button color="accent">
+          <button [disabled]="addEmptyForm.invalid || addEmptyForm.pending" mat-stroked-button>
             <span class="">Recognize Column as Empty</span>
           </button>
         </div>
@@ -86,9 +86,9 @@
         <li class="space-between align-items-center my-4 flex w-1/2 flex-row border-b-2 py-2">
           <div class="flex self-center">{{ c.display_name }}</div>
           <div class="ml-auto flex justify-self-end">
-            <a (click)="removeMergeProtected(c)" mat-stroked-button color="warn">
-              <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-            </a>
+            <button (click)="removeMergeProtected(c)" mat-icon-button>
+              <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+            </button>
           </div>
         </li>
       }
@@ -104,7 +104,7 @@
           </mat-select>
         </mat-form-field>
         <div>
-          <button [disabled]="addMergeProtectedForm.invalid || addMergeProtectedForm.pending" mat-flat-button color="accent">
+          <button [disabled]="addMergeProtectedForm.invalid || addMergeProtectedForm.pending" mat-stroked-button>
             <span class="">Add Merge Protection</span>
           </button>
         </div>
@@ -117,7 +117,7 @@
   <button (click)="save()" mat-flat-button color="primary">
     <span class="">Save Changes</span>
   </button>
-  <button (click)="cancel()" mat-flat-button color="accent">
+  <button (click)="cancel()" mat-stroked-button>
     <span class="">Cancel</span>
   </button>
 </div>

--- a/src/app/modules/organizations/columns/list/list.component.html
+++ b/src/app/modules/organizations/columns/list/list.component.html
@@ -35,16 +35,16 @@
     <ng-container matColumnDef="actions">
       <th class="select-none" *matHeaderCellDef mat-header-cell>Actions</th>
       <td class="w-50 py-2" *matCellDef="let c" mat-cell>
-        <a class="mr-2" (click)="edit(c)" mat-stroked-button>
-          <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil" matTooltip="Edit Column"></mat-icon>
-        </a>
-        <a class="mr-2" (click)="rename(c)" mat-stroked-button>
-          <mat-icon class="icon-size-4" svgIcon="fa-solid:copy" matTooltip="Rename Column"></mat-icon>
-        </a>
+        <button class="mr-2" (click)="edit(c)" mat-icon-button>
+          <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil" matTooltip="Edit Column"></mat-icon>
+        </button>
+        <button class="mr-2" (click)="rename(c)" mat-icon-button>
+          <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:copy" matTooltip="Rename Column"></mat-icon>
+        </button>
         @if (c.is_extra_data) {
-          <a (click)="delete(c)" mat-stroked-button color="warn">
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:x" matTooltip="Delete Column"></mat-icon>
-          </a>
+          <button (click)="delete(c)" mat-icon-button>
+            <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash" matTooltip="Delete Column"></mat-icon>
+          </button>
         }
       </td>
     </ng-container>

--- a/src/app/modules/organizations/columns/mappings/action-buttons.component.html
+++ b/src/app/modules/organizations/columns/mappings/action-buttons.component.html
@@ -1,6 +1,6 @@
-<a (click)="edit($event)" mat-stroked-button>
-  <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil"></mat-icon>
-</a>
-<a (click)="delete($event)" mat-stroked-button color="warn">
-  <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-</a>
+<button (click)="edit($event)" mat-icon-button>
+  <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+</button>
+<button (click)="delete($event)" mat-icon-button>
+  <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+</button>

--- a/src/app/modules/organizations/columns/mappings/mappings.component.html
+++ b/src/app/modules/organizations/columns/mappings/mappings.component.html
@@ -25,12 +25,7 @@
   <button [disabled]="profileReadOnly() || changesToSave" (click)="rename()" mat-icon-button matTooltip="Rename Profile">
     <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
   </button>
-  <button
-    [disabled]="profileReadOnly() || changesToSave"
-    (click)="delete()"
-    mat-icon-button
-    matTooltip="Delete This Profile"
-  >
+  <button [disabled]="profileReadOnly() || changesToSave" (click)="delete()" mat-icon-button matTooltip="Delete This Profile">
     <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
   </button>
   <button (click)="copy_profile()" mat-icon-button matTooltip="Copy This Profile">
@@ -43,20 +38,10 @@
     <mat-icon class="scale-75 fill-green-700" svgIcon="fa-solid:download"></mat-icon>
   </button>
   @if (selectedProfile && mappablePropertyColumns && mappableTaxlotColumns) {
-    <button
-      [disabled]="profileReadOnly()"
-      (click)="copy()"
-      mat-icon-button
-      matTooltip="Copy Data File Headers directly to SEED Headers"
-    >
+    <button [disabled]="profileReadOnly()" (click)="copy()" mat-icon-button matTooltip="Copy Data File Headers directly to SEED Headers">
       <mat-icon class="scale-75 fill-blue-400" svgIcon="fa-solid:file-import"></mat-icon>
     </button>
-    <button
-      [disabled]="profileReadOnly()"
-      (click)="suggest()"
-      mat-icon-button
-      matTooltip="Populate SEED Headers with Best Known Matches"
-    >
+    <button [disabled]="profileReadOnly()" (click)="suggest()" mat-icon-button matTooltip="Populate SEED Headers with Best Known Matches">
       <mat-icon class="scale-75 fill-blue-400" svgIcon="fa-solid:clipboard-check"></mat-icon>
     </button>
   }

--- a/src/app/modules/organizations/columns/mappings/mappings.component.html
+++ b/src/app/modules/organizations/columns/mappings/mappings.component.html
@@ -3,11 +3,11 @@
   <p>Changes made to profiles must be saved - or discarded - before switching to another profile.</p>
 </div>
 
-<div class="flex flex-row">
+<div class="flex flex-row gap-2">
   <button class="flex" [disabled]="!changesToSave" (click)="save()" mat-flat-button color="primary">
     <span class="">Save Changes</span>
   </button>
-  <button class="flex" [disabled]="!changesToSave" (click)="cancel()" mat-flat-button color="accent">
+  <button class="flex" [disabled]="!changesToSave" (click)="cancel()" mat-stroked-button>
     <span class="">Discard Changes</span>
   </button>
 </div>
@@ -22,47 +22,43 @@
       </mat-select>
     </mat-form-field>
   </form>
-  <a class="flex" [disabled]="profileReadOnly() || changesToSave" (click)="rename()" mat-stroked-button matTooltip="Rename Profile">
-    <mat-icon class="fill-blue-700 icon-size-4" svgIcon="fa-solid:eraser"></mat-icon>
-  </a>
-  <a
-    class="flex"
+  <button [disabled]="profileReadOnly() || changesToSave" (click)="rename()" mat-icon-button matTooltip="Rename Profile">
+    <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+  </button>
+  <button
     [disabled]="profileReadOnly() || changesToSave"
     (click)="delete()"
-    mat-stroked-button
-    mat-stroked-button
+    mat-icon-button
     matTooltip="Delete This Profile"
   >
-    <mat-icon class="fill-red-700 icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-  </a>
-  <a class="flex" (click)="copy_profile()" mat-stroked-button matTooltip="Copy This Profile">
-    <mat-icon class="fill-cyan-600 icon-size-4" svgIcon="fa-solid:copy"></mat-icon>
-  </a>
-  <a class="flex" (click)="create_profile()" mat-stroked-button matTooltip="Create New Profile">
-    <mat-icon class="fill-gray-700 icon-size-4 dark:fill-gray-200" svgIcon="fa-solid:folder-plus"></mat-icon>
-  </a>
-  <a class="flex" (click)="export()" mat-stroked-button matTooltip="Download as CSV">
-    <mat-icon class="fill-green-700 icon-size-4" svgIcon="fa-solid:download"></mat-icon>
-  </a>
+    <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+  </button>
+  <button (click)="copy_profile()" mat-icon-button matTooltip="Copy This Profile">
+    <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:copy"></mat-icon>
+  </button>
+  <button (click)="create_profile()" mat-icon-button matTooltip="Create New Profile">
+    <mat-icon class="scale-75 fill-primary-700" svgIcon="fa-solid:plus"></mat-icon>
+  </button>
+  <button (click)="export()" mat-icon-button matTooltip="Download as CSV">
+    <mat-icon class="scale-75 fill-green-700" svgIcon="fa-solid:download"></mat-icon>
+  </button>
   @if (selectedProfile && mappablePropertyColumns && mappableTaxlotColumns) {
-    <a
-      class="flex"
+    <button
       [disabled]="profileReadOnly()"
       (click)="copy()"
-      mat-stroked-button
+      mat-icon-button
       matTooltip="Copy Data File Headers directly to SEED Headers"
     >
-      <mat-icon class="fill-blue-400 icon-size-4" svgIcon="fa-solid:file-import"></mat-icon>
-    </a>
-    <a
-      class="flex"
+      <mat-icon class="scale-75 fill-blue-400" svgIcon="fa-solid:file-import"></mat-icon>
+    </button>
+    <button
       [disabled]="profileReadOnly()"
       (click)="suggest()"
-      mat-stroked-button
+      mat-icon-button
       matTooltip="Populate SEED Headers with Best Known Matches"
     >
-      <mat-icon class="fill-blue-400 icon-size-4" svgIcon="fa-solid:clipboard-check"></mat-icon>
-    </a>
+      <mat-icon class="scale-75 fill-blue-400" svgIcon="fa-solid:clipboard-check"></mat-icon>
+    </button>
   }
 </div>
 

--- a/src/app/modules/organizations/columns/mappings/modal/create-modal.component.html
+++ b/src/app/modules/organizations/columns/mappings/modal/create-modal.component.html
@@ -51,9 +51,9 @@
             <mat-label>File Header {{ i + 1 }}</mat-label>
             <input formControlName="from_field" matInput placeholder="File Header {{ i + 1 }}" />
           </mat-form-field>
-          <a class="flex flex-0" (click)="removeMapping(i)" mat-stroked-button matTooltip="Remove">
-            <mat-icon class="fill-red-700 icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-          </a>
+          <button class="flex flex-0" (click)="removeMapping(i)" mat-icon-button matTooltip="Remove">
+            <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+          </button>
         </div>
       }
     </div>
@@ -64,7 +64,7 @@
   <div class="flex flex-1">
     <mat-dialog-actions>
       <button (click)="addMapping()" mat-stroked-button matTooltip="Add File Header">
-        <mat-icon class="fill-blue-700 icon-size-4" svgIcon="fa-solid:circle-plus"></mat-icon><span class="ml-2">Add Row</span>
+        <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:plus"></mat-icon><span class="ml-2">Add Row</span>
       </button>
     </mat-dialog-actions>
   </div>

--- a/src/app/modules/organizations/columns/matching-criteria/criteria-list.component.html
+++ b/src/app/modules/organizations/columns/matching-criteria/criteria-list.component.html
@@ -7,9 +7,9 @@
     <div class="flex w-2/3 text-lg">{{ column.display_name }}</div>
     <div class="flex w-1/3">
       @if (canRemove(column)) {
-        <a class="flex" (click)="removeColumn(column)" mat-stroked-button matTooltip="Remove Column From Matching Criteria">
-          <mat-icon class="fill-red-700 icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-        </a>
+        <button (click)="removeColumn(column)" mat-icon-button matTooltip="Remove Column From Matching Criteria">
+          <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+        </button>
       } @else {
         Locked
       }

--- a/src/app/modules/organizations/cycles/cycles.component.html
+++ b/src/app/modules/organizations/cycles/cycles.component.html
@@ -33,12 +33,12 @@
       <ng-container matColumnDef="actions">
         <th class="select-none pr-24 text-right" *matHeaderCellDef mat-header-cell>Actions</th>
         <td class="w-50 text-right" *matCellDef="let cycle" mat-cell>
-          <a class="mr-2" (click)="editCycle(cycle)" mat-stroked-button>
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil"></mat-icon>
-          </a>
-          <a (click)="deleteCycle(cycle)" mat-stroked-button color="warn">
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-          </a>
+          <button class="mr-2" (click)="editCycle(cycle)" mat-icon-button>
+            <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+          </button>
+          <button (click)="deleteCycle(cycle)" mat-icon-button>
+            <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+          </button>
         </td>
       </ng-container>
 

--- a/src/app/modules/organizations/data-quality/goal/goal-table.component.html
+++ b/src/app/modules/organizations/data-quality/goal/goal-table.component.html
@@ -47,12 +47,12 @@
   <ng-container matColumnDef="actions">
     <th class="select-none pr-24 text-right" *matHeaderCellDef mat-header-cell>Actions</th>
     <td class="w-50 text-right" *matCellDef="let rule" mat-cell>
-      <a class="mr-2" (click)="editRule(rule)" mat-stroked-button>
-        <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil"></mat-icon>
-      </a>
-      <a (click)="deleteRule(rule)" mat-stroked-button color="warn">
-        <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-      </a>
+      <button class="mr-2" (click)="editRule(rule)" mat-icon-button>
+        <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+      </button>
+      <button (click)="deleteRule(rule)" mat-icon-button>
+        <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+      </button>
     </td>
   </ng-container>
 

--- a/src/app/modules/organizations/data-quality/inventory/inventory-table.component.html
+++ b/src/app/modules/organizations/data-quality/inventory/inventory-table.component.html
@@ -41,12 +41,12 @@
   <ng-container matColumnDef="actions">
     <th class="select-none pr-24 text-right" *matHeaderCellDef mat-header-cell>Actions</th>
     <td class="w-50 text-right" class="whitespace-nowrap text-right" *matCellDef="let rule" mat-cell>
-      <a class="mr-2" (click)="editRule(rule)" mat-stroked-button>
-        <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil"></mat-icon>
-      </a>
-      <a (click)="deleteRule(rule)" mat-stroked-button color="warn">
-        <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-      </a>
+      <button class="mr-2" (click)="editRule(rule)" mat-icon-button>
+        <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+      </button>
+      <button (click)="deleteRule(rule)" mat-icon-button>
+        <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+      </button>
     </td>
   </ng-container>
 

--- a/src/app/modules/organizations/derived-columns/derived-columns.component.html
+++ b/src/app/modules/organizations/derived-columns/derived-columns.component.html
@@ -25,12 +25,12 @@
       <ng-container matColumnDef="actions">
         <th class="select-none pr-24 text-right" *matHeaderCellDef mat-header-cell>Actions</th>
         <td class="w-50 text-right" *matCellDef="let dc" mat-cell>
-          <a class="mr-2" (click)="editDerivedColumn(dc)" mat-stroked-button>
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil"></mat-icon>
-          </a>
-          <a (click)="deleteDerivedColumn(dc)" mat-stroked-button color="warn">
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-          </a>
+          <button class="mr-2" (click)="editDerivedColumn(dc)" mat-icon-button>
+            <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+          </button>
+          <button (click)="deleteDerivedColumn(dc)" mat-icon-button>
+            <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+          </button>
         </td>
       </ng-container>
 

--- a/src/app/modules/organizations/derived-columns/modal/form-modal.component.html
+++ b/src/app/modules/organizations/derived-columns/modal/form-modal.component.html
@@ -45,9 +45,9 @@
         </mat-form-field>
 
         @if (parameters.controls.length > 1) {
-          <a class="mt-7" (click)="deleteParameter($index)" mat-stroked-button color="warn">
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-          </a>
+          <button class="mt-7" (click)="deleteParameter($index)" mat-icon-button>
+            <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+          </button>
         }
       </div>
     }
@@ -57,7 +57,7 @@
     }
 
     <a (click)="addParameter()" mat-flat-button color="primary">
-      <mat-icon class="icon-size-4" svgIcon="fa-solid:plus"></mat-icon>
+      <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:plus"></mat-icon>
       <span class="ml-2">Add Parameter</span>
     </a>
 

--- a/src/app/modules/organizations/derived-columns/modal/form-modal.component.html
+++ b/src/app/modules/organizations/derived-columns/modal/form-modal.component.html
@@ -57,7 +57,7 @@
     }
 
     <a (click)="addParameter()" mat-flat-button color="primary">
-      <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:plus"></mat-icon>
+      <mat-icon class="fill-white icon-size-4" svgIcon="fa-solid:plus"></mat-icon>
       <span class="ml-2">Add Parameter</span>
     </a>
 

--- a/src/app/modules/organizations/email-templates/email-templates.component.html
+++ b/src/app/modules/organizations/email-templates/email-templates.component.html
@@ -69,7 +69,7 @@
     <seed-not-found message="No Email Templates Found" icon="fa-solid:triangle-exclamation"> </seed-not-found>
     <div class="mt-4 flex w-full justify-center">
       <button class="flex gap-4" (click)="create()" mat-raised-button color="primary">
-        <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:plus"></mat-icon> Create New Template
+        <mat-icon class="fill-white icon-size-4" svgIcon="fa-solid:plus"></mat-icon> Create New Template
       </button>
     </div>
   } @else {

--- a/src/app/modules/organizations/email-templates/email-templates.component.html
+++ b/src/app/modules/organizations/email-templates/email-templates.component.html
@@ -53,15 +53,15 @@
       </mat-form-field>
     </form>
     <!-- template actions -->
-    <a class="flex" [disabled]="!selectedTemplate" (click)="rename()" mat-stroked-button matTooltip="Rename">
-      <mat-icon class="fill-blue-700 icon-size-4" svgIcon="fa-solid:eraser"></mat-icon>
-    </a>
-    <a class="flex" [disabled]="!selectedTemplate" (click)="delete()" mat-stroked-button matTooltip="Delete">
-      <mat-icon class="fill-red-700 icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-    </a>
-    <a class="flex" (click)="create()" mat-stroked-button matTooltip="Create New">
-      <mat-icon class="fill-gray-700 icon-size-4 dark:fill-gray-200" svgIcon="fa-solid:folder-plus"></mat-icon>
-    </a>
+    <button [disabled]="!selectedTemplate" (click)="rename()" mat-icon-button matTooltip="Rename">
+      <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+    </button>
+    <button [disabled]="!selectedTemplate" (click)="delete()" mat-icon-button matTooltip="Delete">
+      <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+    </button>
+    <button (click)="create()" mat-icon-button matTooltip="Create New">
+      <mat-icon class="scale-75 fill-primary-700" svgIcon="fa-solid:plus"></mat-icon>
+    </button>
   </div>
 
   <!-- email template -->
@@ -69,7 +69,7 @@
     <seed-not-found message="No Email Templates Found" icon="fa-solid:triangle-exclamation"> </seed-not-found>
     <div class="mt-4 flex w-full justify-center">
       <button class="flex gap-4" (click)="create()" mat-raised-button color="primary">
-        <mat-icon class="fill-gray-700 icon-size-4 dark:fill-gray-200" svgIcon="fa-solid:folder-plus"></mat-icon> Create New Template
+        <mat-icon class="fill-primary-700 icon-size-4" svgIcon="fa-solid:plus"></mat-icon> Create New Template
       </button>
     </div>
   } @else {

--- a/src/app/modules/organizations/labels/labels.component.html
+++ b/src/app/modules/organizations/labels/labels.component.html
@@ -23,12 +23,12 @@
       <ng-container matColumnDef="actions">
         <th *matHeaderCellDef mat-header-cell>Actions</th>
         <td class="w-50" *matCellDef="let label" mat-cell>
-          <a (click)="edit(label)" mat-stroked-button>
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil"></mat-icon>
-          </a>
-          <a (click)="delete(label)" mat-stroked-button color="warn">
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-          </a>
+          <button (click)="edit(label)" mat-icon-button>
+            <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+          </button>
+          <button (click)="delete(label)" mat-icon-button>
+            <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+          </button>
         </td>
       </ng-container>
       <thead>

--- a/src/app/modules/organizations/members/members.component.html
+++ b/src/app/modules/organizations/members/members.component.html
@@ -30,12 +30,12 @@
       <ng-container matColumnDef="actions">
         <th class="select-none" *matHeaderCellDef mat-header-cell>Actions</th>
         <td class="w-50 whitespace-nowrap text-right" *matCellDef="let member" mat-cell>
-          <a class="mr-2" (click)="editMember(member)" mat-stroked-button>
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil"></mat-icon>
-          </a>
-          <a (click)="deleteMember(member)" mat-stroked-button color="warn">
-            <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-          </a>
+          <button class="mr-2" (click)="editMember(member)" mat-icon-button>
+            <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+          </button>
+          <button (click)="deleteMember(member)" mat-icon-button>
+            <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+          </button>
         </td>
       </ng-container>
 

--- a/src/app/modules/organizations/settings/audit-template/audit-template.component.html
+++ b/src/app/modules/organizations/settings/audit-template/audit-template.component.html
@@ -94,7 +94,7 @@
               <mat-slide-toggle formControlName="audit_template_conditional_import">{{ t('Enable Conditional Import') }}</mat-slide-toggle>
             </div>
             <div class="my-6">
-              <button [attr.aria-label]="'Import Submissions'" (click)="importSubmissions()" mat-flat-button color="accent" type="button">
+              <button [attr.aria-label]="'Import Submissions'" (click)="importSubmissions()" mat-stroked-button type="button">
                 Import Submissions
               </button>
             </div>

--- a/src/app/modules/organizations/settings/salesforce/salesforce.component.html
+++ b/src/app/modules/organizations/settings/salesforce/salesforce.component.html
@@ -77,7 +77,7 @@
                     </mat-form-field>
                   </div>
                   <div>
-                    <button (click)="testConnection()" type="button" mat-raised-button color="accent">Test Connection</button>
+                    <button (click)="testConnection()" type="button" mat-stroked-button>Test Connection</button>
                   </div>
                   @if (testConnectionStatus === 'success') {
                     <div class="mt-2 flex items-center space-x-2 rounded-lg bg-green-50 p-3 text-green-700">
@@ -134,7 +134,7 @@
                         {{ t('Last Salesforce Update') }}: {{ salesforceConfig.last_update_date || 'N/A' }}
                       </div>
                       @if (salesforceConfig.last_update_date) {
-                        <button (click)="resetUpdateDate()" type="button" mat-raised-button color="accent">Reset</button>
+                        <button (click)="resetUpdateDate()" type="button" mat-stroked-button>Reset</button>
                       }
                     </div>
                   }
@@ -463,7 +463,7 @@
                           <mat-icon class="icon-size-5" svgIcon="heroicons-solid:x-circle" />
                           <span>{{ t('Not connected to Salesforce') }}</span>
                         </div>
-                        <button (click)="bbLogin()" type="button" mat-raised-button color="accent">{{ t('Login') }}</button>
+                        <button (click)="bbLogin()" type="button" mat-stroked-button>{{ t('Login') }}</button>
                       }
                     </div>
                   </div>
@@ -499,12 +499,12 @@
                 <ng-container matColumnDef="actions">
                   <th class="select-none" *matHeaderCellDef mat-header-cell>Actions</th>
                   <td class="w-50 py-2" *matCellDef="let sfm" mat-cell>
-                    <a class="mr-2" (click)="editMapping(sfm)" mat-stroked-button>
-                      <mat-icon class="icon-size-4" svgIcon="fa-solid:pencil"></mat-icon>
-                    </a>
-                    <a (click)="deleteMapping(sfm)" mat-stroked-button color="warn">
-                      <mat-icon class="icon-size-4" svgIcon="fa-solid:x"></mat-icon>
-                    </a>
+                    <button class="mr-2" (click)="editMapping(sfm)" mat-icon-button>
+                      <mat-icon class="scale-75 fill-cyan-600" svgIcon="fa-solid:pencil"></mat-icon>
+                    </button>
+                    <button (click)="deleteMapping(sfm)" mat-icon-button>
+                      <mat-icon class="scale-75 fill-red-700" svgIcon="fa-solid:trash"></mat-icon>
+                    </button>
                   </td>
                 </ng-container>
 

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -249,6 +249,26 @@
   @apply border border-primary bg-primary py-1 px-2 rounded-full whitespace-nowrap text-white
 }
 
+// Fix Material button color theming (M2 color attribute removed in AM v21)
+.mat-mdc-unelevated-button,
+.mat-mdc-raised-button {
+  &[color='primary']:not(:disabled) {
+    @apply bg-primary text-white hover:bg-primary-800 #{'!important'};
+  }
+
+  &[color='primary']:disabled {
+    @apply bg-primary/40 text-white/70 cursor-not-allowed #{'!important'};
+  }
+
+  &[color='warn']:not(:disabled) {
+    @apply bg-warn text-white hover:bg-warn-800 #{'!important'};
+  }
+
+  &[color='warn']:disabled {
+    @apply bg-warn/40 text-white/70 cursor-not-allowed #{'!important'};
+  }
+}
+
 .menu-compact {
   padding: 0.5rem;
   max-height: 60vh;


### PR DESCRIPTION

  Standardizes icon buttons, primary action buttons, and secondary action buttons across the entire
  application for a consistent look and feel.

  Established and applied consistent icon button standards across all pages:

  │ New/Add     │ fa-solid:plus          │ Blue (fill-primary-700)   │
 
  │ Edit/Rename │ fa-solid:pencil        │ Cyan (fill-cyan-600)      │
  
  │ Delete      │ fa-solid:trash         │ Red (fill-red-700)        │

  │ Save        │ fa-solid:floppy-disk   │ Green (fill-green-700)    │

   - Converted all icon-only action buttons from mat-stroked-button (outlined) to mat-icon-button (no
  outline) for cleaner appearance
   - Applied to: default reports, custom reports, filter groups, column profiles, column mappings,
  column list, cycles, data quality, labels, members, derived columns, email templates, import settings,
   geocoding, matching criteria, salesforce, datasets, and data mappings

  Primary Action Button Theming Fix

   - Added global CSS fix for mat-flat-button and mat-raised-button with color="primary" and
  color="warn" — Angular Material v21 dropped the M2 color input on buttons, so these were rendering as
  unstyled text
   - Primary buttons now show blue background with white text; warn buttons show red background with
  white text
   - Disabled primary/warn buttons show a muted version of their color instead of losing all styling