### PR TITLE
Add Copilot instructions and legacy migration guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,132 @@
+# SEED Angular — Copilot Instructions
+
+Angular frontend for the SEED Platform™ (Standard Energy Efficiency Data), paired with a Django
+backend (in the parent `seed` repo). Built with Angular (standalone components, no NgModules),
+Angular Material, TailwindCSS, RxJS, and Transloco for i18n.
+
+## Setup & commands
+
+Package manager is **pnpm** (enforced by a `preinstall` script that fails under npm/yarn). Node
+>=24, pnpm >=10.
+
+- Install: `pnpm i`
+- Dev server (Angular hot reload, proxies `/api/` and `/media/` to Django): `pnpm start`
+  - Proxy target is `SEED_HOST` env var (default `http://127.0.0.1:8000`), configured in
+    `proxy.conf.mjs`. Set it in a `.env` file (see `.env.example`).
+- Dev server through Django: `pnpm watch` — rebuilds on save, output goes to
+  `../../collected_static/ng-app`; Django serves it at `/ng-app/`. Use `pnpm build` for a one-shot
+  build instead of a watcher.
+- Build: `pnpm build`
+- Lint everything: `pnpm lint` (runs eslint + prettier check + stylelint in parallel)
+  - `pnpm eslint` / `pnpm eslint:fix` — `ng lint` (TypeScript + Angular templates)
+  - `pnpm prettier` / `pnpm prettier:fix` — checks/formats `src/**/*.html` only
+  - `pnpm stylelint` / `pnpm stylelint:fix` — checks `src/**/*.scss`
+  - `pnpm lint:fix` runs all three `:fix` variants
+- Spell check: `pnpm cspell "**/*"`. Spelling is *also* checked per-file as part of `pnpm eslint`
+  (via `@cspell/eslint-plugin`), so lint failures can be spelling issues. Add legitimate
+  domain-specific words to `.spelling.dic`, not inline ignore comments.
+- Tests: `pnpm test` (`ng test`, Karma + Jasmine). **No `*.spec.ts` files currently exist in
+  `src/`** — the test runner and config are wired up but unused. To run a single spec once one
+  exists: `ng test --include='**/some.component.spec.ts'`.
+- Update translations from Lokalise: `pnpm update-translations` (needs `.env` with
+  `LOKALISE_TOKEN`; see `transloco.config.ts` for the `public/i18n/` translations path).
+- CI (`.github/workflows/ci.yml`) runs `pnpm install`, `pnpm lint`, `pnpm build` on push/PR to
+  `main`. There is no test step in CI today.
+
+## Architecture
+
+- `src/@seed/` is a self-contained framework layer (derived from the Fuse Angular admin
+  template): `animations`, `components` (UI kit), `directives`, `guards`, `materials` (barrel
+  re-exporting Angular Material modules as `MaterialImports`), `pipes`, `routing`, `services`,
+  `styles`/`tailwind` (theming), `validators`, and its own mock-api interceptor framework. All
+  backend HTTP access lives in `src/@seed/api/<resource>/` (e.g. `organization`, `property`,
+  `cycle`, `column`, `dataset`, `salesforce`...), one folder per REST resource with
+  `<resource>.service.ts` + `<resource>.types.ts`.
+- **Backend API versions:** the Django backend (main `seed` repo) exposes both `/api/v3/` and
+  `/api/v4/` (`seed/api/v3/`, `seed/api/v4/`, wired in `seed/api/base/urls.py`). The overwhelming
+  majority of endpoints this app calls are v3 — reuse the existing v3 endpoint for a resource
+  whenever one already exists (the legacy AngularJS app at `seed/static/seed/` is calling the same
+  v3 endpoints and is a good reference for the request/response shape). Only call/introduce a
+  `/api/v4/` endpoint when the feature genuinely needs a new backend endpoint that has no v3
+  equivalent (see the handful of existing `/api/v4/` calls in `organization.service.ts`,
+  `analysis.service.ts`, `groups.service.ts`, `inventory.service.ts` for precedent) — don't default
+  to v4 just because it's newer, and never add a new v3 endpoint.
+- `src/app/` is the actual application: `core/` (auth, icons, navigation, snack-bar, transloco
+  wiring), `layout/`, `modules/` (feature areas — `inventory`, `inventory-list`,
+  `inventory-detail`, `organizations`, `datasets`, `data-quality`, `analyses`, `insights`,
+  `profile`, `auth`, `main`, `api`, `column-list-profile`, `data`), and an app-specific
+  `mock-api/`.
+- No TS path aliases are configured — `tsconfig.json` just sets `baseUrl: "./src"`, so
+  `@seed/...` and `app/...` imports resolve because those directories are literally named `@seed`
+  and `app` under `src/`. Avoid deep relative (`../../..`) imports across that boundary.
+- Routing is fully lazy: each feature exports a default `Routes` array
+  (`<feature>.routes.ts`, e.g. `organizations.routes.ts`) loaded via
+  `loadChildren: () => import('app/modules/<feature>/<feature>.routes')` (see `app.routes.ts`).
+  Polymorphic paths (e.g. inventory `properties`/`taxlots`, org `data-quality`/`derived-columns`
+  sub-types) use custom `UrlSegment` matcher functions instead of static path strings.
+- `app.config.ts` wires: Transloco, a custom `TitleStrategy` (appends "- SEED Platform™"), a
+  Luxon-based Material `DateAdapter`, `provideAuth()`, `provideIcons()`, and `provideSEED(...)`
+  (defined in `src/@seed/seed.provider.ts`), which registers SEED-wide providers (confirmation
+  dialogs, loading/media/platform/splash-screen services, HTTP interceptors) and optionally the
+  mock-API HTTP interceptor for local dev without a live Django backend.
+
+## Migrating legacy pages
+
+This app is actively replacing a legacy AngularJS 1.x frontend (`seed/static/seed/` in the main
+`seed` repo, of which this repo is a git submodule). If asked to port a page/feature from that
+app, see `MIGRATION.md` in this repo's root for the playbook and a tracked checklist of what's
+left.
+
+## Key conventions
+
+Full guidelines are in `DEVELOPER.md` — highlights that are easy to miss:
+
+- Standalone components only. `@Component({ imports: [...] })`, separate `.html`/`.scss` files,
+  kebab-case selectors prefixed with `seed`, `auth`, or `layout` (enforced by eslint).
+- Use `type`, never `interface`, for shapes; never use `any`.
+- Inject dependencies with `inject()` at the field level, not constructor params. Private fields
+  are prefixed `_` (e.g. `private _cycleService = inject(CycleService)`) — enforced by eslint
+  naming-convention rule.
+- Services hold state in a private `ReplaySubject`/`BehaviorSubject` and expose a public
+  `<name>$` `Observable` property. Any observable-holding variable gets a `$` suffix.
+- Unsubscribe pattern: `private readonly _unsubscribeAll$ = new Subject<void>()`, pipe with
+  `takeUntil(this._unsubscribeAll$)`, call `.next()`/`.complete()` in `ngOnDestroy`. `HttpClient`
+  requests complete on their own and don't need this.
+- Consume Angular Material via the `MaterialImports` barrel from `@seed/materials` rather than
+  importing individual Material modules directly.
+- Every user-facing string needs a Transloco translation key (see `public/i18n/`).
+- Import order/sorting and single-quote/no-semicolon style are eslint/prettier-enforced — run
+  `pnpm lint:fix` rather than hand-formatting.
+- **Prefer readability over clever code.** Favor small, single-purpose methods/getters and early
+  returns over dense one-liners, deep ternary chains, or clever RxJS chaining. Move non-trivial
+  logic out of templates and into the component class rather than inlining it in the HTML. This is
+  also why the app avoids `lodash`/large utility libs (see `DEVELOPER.md`) — plain, explicit code
+  is preferred over "clever" abstractions.
+
+### CSS & UI (TailwindCSS + Angular Material)
+
+- TailwindCSS utility-first, mobile-first; components must support both light and dark themes.
+  Avoid broad/global SCSS — scope styles to the component.
+- **Colors:** never hardcode hex/rgb colors in templates or SCSS. Use the semantic utilities the
+  theme plugin generates from `tailwind.config.ts` (`text-primary-{50-900}`, `bg-card`,
+  `text-secondary`, etc. — see `src/@seed/tailwind/plugins/theming.ts`), which already adapt
+  between light/dark; add a `dark:` variant only for a one-off value the theme doesn't cover. On
+  Angular Material components, express intent with `color="primary"`/`"accent"`/`"warn"` instead
+  of custom background/text colors. If you must reference a `--seed-*` CSS variable directly in
+  SCSS, use the `rgb(var(--seed-*-rgb) / <alpha>)` form — the comma `rgba(var(...), a)` form is
+  blocked by stylelint.
+- **Buttons:** pick the Material button variant that matches intent — `mat-flat-button` for a
+  primary action, `mat-stroked-button` for secondary/cancel, `mat-icon-button` for icon-only,
+  `mat-raised-button` for a destructive/`warn` action (see any `modal/*.component.html` for the
+  pattern) — and let Material's own padding stand; don't add custom `padding`/`px-*`/`py-*` to
+  resize a button. For a page's primary (and optional secondary) action button, don't hand-roll
+  one at all — pass `action`/`actionIcon`/`actionText` (and `action2*`) into
+  `<seed-page [config]="...">`, which renders it consistently (see
+  `organizations/cycles/cycles.component.html`).
+- **Icon sizing:** size `mat-icon` with the custom `icon-size-*` scale (e.g. `icon-size-4`,
+  `icon-size-5` — defined in `src/@seed/tailwind/plugins/icon-size.ts`), not raw `w-*`/`h-*`
+  classes.
+- **Spacing:** prefer flex/grid `gap-*` utilities for space between sibling elements over
+  `space-x-*`/`space-y-*` or manual `mr-*`/`ml-*` on individual children — `gap-*` is the dominant
+  pattern in this codebase by a wide margin. Reach for the extended spacing scale in
+  `tailwind.config.ts` (`theme.extend.spacing`) instead of arbitrary-value classes like `p-[13px]`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,170 @@
+# Migrating pages from the legacy AngularJS app
+
+This document is the playbook for porting a page/feature from the legacy AngularJS frontend
+(`seed/static/seed/` in the main [`seed`](https://github.com/SEED-platform/seed) repo) into this
+Angular app, plus a tracked checklist of what's left.
+
+For general coding conventions of *this* app, see `DEVELOPER.md` and `.github/copilot-instructions.md`.
+This document only covers the migration process itself.
+
+## Why two frontends exist right now
+
+SEED is mid-migration from an AngularJS 1.x SPA to this Angular app. Both currently run side by
+side, served by the same Django backend (`config/urls.py` in the main repo):
+
+- **Legacy app** — AngularJS 1.x, served under `/app/` (`seed.urls`). Source lives in the main
+  `seed` repo at `seed/static/seed/`:
+  - `js/seed.js` — the `$stateProvider` route table (the authoritative list of every legacy page,
+    its URL, its `templateUrl`, and its controller).
+  - `js/controllers/<name>_controller.js` — one controller per page or modal.
+  - `js/services/`, `js/directives/`, `js/filters/` — shared AngularJS services/directives/filters.
+  - `partials/<name>.html` — the AngularJS templates (`ng-repeat`, `ui-sref`, `{$:: ... $}`
+    interpolation, etc.).
+  - `locales/<lang>.json` — legacy translation strings, keyed by the English source string.
+- **This app** — served under `/ng-app/` as a static SPA (`ng_seed/views.py::seed_angular` serves
+  `index.html` for any non-file `/ng-app/*` request). This repo (`ng_seed/seed-angular`) is a **git
+  submodule** of the main `seed` repo — it has its own git history/remote, separate from the
+  Django backend.
+
+There is currently no in-app link from the legacy UI to the new one (or vice versa) for
+already-migrated pages — cutover/navigation strategy is decided outside this repo. Don't assume a
+page is "live" for users just because it exists here; check with the team before removing/altering
+the legacy route for something you just migrated.
+
+## Playbook: porting one page
+
+1. **Find the legacy route.** Search `seed/static/seed/js/seed.js` for the `.state({ name: '...' })`
+   block for the page (or grep the URL/partial name). Note its `url`, `templateUrl`, `controller`,
+   and any `resolve` block (these usually prefetch data via services — they typically become either
+   an Angular route `resolve` or a plain `ngOnInit`/service call in the new component).
+2. **Read the legacy controller + partial.** `js/controllers/<name>_controller.js` and
+   `partials/<name>.html`. Also check for companion **modal** controllers/partials
+   (`<name>_modal_controller.js` + `<name>_modal.html`) used by the page — these become
+   `MatDialog`-based standalone components under a local `modal/` folder, mirroring existing
+   examples like `modules/organizations/cycles/modal/`.
+3. **Find or create the API service.** Identify the backend endpoints the controller calls
+   (`$http`/Restangular calls to `/api/v3/...`). Check whether a matching service already exists
+   under `src/@seed/api/<resource>/` — most resources already have one (`organization`, `cycle`,
+   `property`, `column`, `pairing`, `salesforce`, etc.). If not, add `<resource>.service.ts` +
+   `<resource>.types.ts` following the existing pattern: `@Injectable({ providedIn: 'root' })`,
+   `inject(HttpClient)`, private `ReplaySubject`/`BehaviorSubject` state with a public `<name>$`
+   observable. **Call the same `/api/v3/...` endpoint the legacy controller already uses** — a
+   migration should not require backend changes. Only reach for a new `/api/v4/...` endpoint (in
+   the main `seed` repo's `seed/api/v4/`) if the page genuinely needs backend behavior that has no
+   v3 endpoint at all; that's a backend change coordinated separately, not something to add
+   speculatively while porting a page.
+4. **Build the new page** as standalone component(s) under `src/app/modules/<feature>/...`, and
+   wire it into that feature's `<feature>.routes.ts` (default-exported `Routes` array), following
+   the URL shape of sibling routes already migrated in the same feature area (paths have often been
+   reshaped to kebab-case, e.g. legacy `inventory_cycles` → new `cross-cycles`, legacy
+   `insights_program` → new `program-overview`; match existing renamed siblings rather than the
+   legacy URL literally).
+5. **Convert the template.** Common substitutions:
+   | Legacy (AngularJS) | New (Angular) |
+   |---|---|
+   | `ng-repeat="x in items"` | `@for (x of items; track x.id)` |
+   | `ng-if` / `ng-show` / `ng-hide` | `@if` |
+   | `ui-sref="stateName"` | `routerLink="/path"` |
+   | `{$:: 'Text' $}` / `translate` filter/directive | `{{ 'Text' \| transloco }}` |
+   | `ng-model` two-way binding | Reactive forms (`FormControl`/`FormGroup`) |
+   | `$scope.x` | component class field |
+   | Bootstrap classes, custom CSS | Tailwind utility classes (mobile-first, light+dark theme) |
+   | AngularJS service (`js/services/*.js`) | injectable Angular service, `providedIn: 'root'` |
+6. **Reuse translations, don't retranslate.** Both apps use the same flat
+   `{ "English string": "translated string" }` JSON format, with matching keys in
+   `seed/static/seed/locales/<lang>.json` (legacy) and `public/i18n/<lang>.json` (this app). Copy
+   the existing key/value pairs for the strings you're porting instead of re-authoring them; only
+   run `pnpm update-translations` / involve Lokalise for genuinely new strings.
+7. **Follow this repo's conventions** (standalone components with an `imports` array, `inject()`
+   for DI, `_`-prefixed private fields, `$`-suffixed observables, `MaterialImports` barrel,
+   `takeUntil(this._unsubscribeAll$)` cleanup) — see `DEVELOPER.md` for the full list.
+8. **Validate** with `pnpm lint` and `pnpm build` before considering the port done.
+9. **Do not delete or edit the legacy AngularJS code** as part of a migration PR unless explicitly
+   asked to — the legacy route keeps serving production traffic under `/app/` until a separate
+   decision is made to retire it.
+
+## Migration status
+
+Checklist derived from every `.state()` entry in `seed/static/seed/js/seed.js` (63 total), compared
+against this app's route files. Update this table as pages move between columns.
+
+### Not yet migrated
+
+- [ ] **Personal two-factor setup** (`/profile/two_factor_profile`, `two_factor_profile_controller`)
+      — user's own 2FA device enrollment. (Org-level two-factor *policy* settings are already
+      migrated to `organizations/settings/two-factor`; this is the separate personal setup flow.)
+- [ ] **Pairing workflow** (`/data/pairing/:importfile_id/{properties|taxlots}`,
+      `pairing_controller`) — the property/tax-lot pairing UI after an import. The dataset page
+      (`modules/datasets/dataset/dataset.component.ts`) already has a "Data Pairing" button, but it
+      currently only `console.log`s — the workflow itself isn't built.
+- [ ] **Pairing settings** (`/data/pairing/:importfile_id/{type}/settings`, `pairing_settings_controller`)
+      — companion settings page for the above.
+- [ ] **Salesforce login callback** (`/salesforce_login`, `salesforce_login_controller`) — the
+      OAuth success/failure landing page. (Distinct from Salesforce org *settings*, which are
+      already migrated to `organizations/settings/salesforce`.)
+- [ ] **Organization sharing** (`/accounts/:organization_id/sharing`, `organization_sharing_controller`)
+      — cross-org data sharing settings tab.
+- [ ] **Program setup** (`/accounts/:organization_id/program_setup[/:id]`, `program_setup_controller`)
+      — BuildingSync/program configuration for an org, under org settings. (Don't confuse with
+      `ProgramConfigComponent` in `insights/config/` — that's a smaller compliance-metric picker
+      embedded in the already-migrated `program-overview`/`property-insights` pages, not the
+      full org-level program CRUD admin page.)
+- [ ] **Sub-organizations** (`/accounts/:organization_id/sub_org`, `organization_controller`) —
+      create/manage child organizations.
+- [ ] **Inventory plots** (`/{properties|taxlots}/plots`, `inventory_plots_controller`) — charting
+      view over inventory data.
+- [ ] **Facilities Plan** (`/insights/facilities_plan`, `facilities_plan_controller`) — the
+      facilities/systems/services planning landing page. (Note: the `service_detail` sub-page it
+      links to *is* already migrated, under `inventory/groups/:groupId/systems/services/:systemId/:serviceId`.)
+      **In progress:** see the `facilities-plan` branch (no PR yet) — has an initial
+      `insights/facilities-plan` component + bulk-edit/delete/form modals already scaffolded.
+      Check that branch before starting new work here.
+
+### Cross-checked against legacy `js/services/`
+
+The checklist above is built from `seed.js`'s route table, so it only catches gaps at the
+page/route level. As a second pass, every legacy `js/services/<name>_service.js` (the AngularJS
+service layer, ~50 files) was cross-checked against this app's `src/@seed/api/` and existing pages
+to look for whole features hiding *inside* an already-migrated page rather than behind their own
+route. Notes from that pass:
+
+- **No additional missing pages found.** Everything reachable from a controller maps to either an
+  already-migrated page (`goal_service`→`data-quality/goal`, `two_factor_service`→personal 2FA
+  above, `compliance_metric_service`→`insights/config/program-config.component.ts`,
+  `map_service`'s EEEJ/disadvantaged-tract filter→`inventory-list/map/map.component.ts`,
+  `property_measure_service`→`inventory-detail/detail` scenarios grid) or a page already on the
+  list above (`facilities_plan_service`/`facilities_plan_run_service`/`service_service`/
+  `system_service`→Facilities Plan; `pairing_service`→Pairing workflow, though the API service
+  itself already exists in `@seed/api/pairing`, only the UI is missing).
+- **Dead/unused in the legacy app** — not referenced by any legacy controller, so don't bother
+  porting them: `element_service`, `uniformat_service`, `event_service`.
+- **Cross-cutting utilities, not features** — no dedicated page to port, these are legacy
+  plumbing (`modified_service` "stale record" banner, `search_service`, `http_serializer`,
+  `main_service`, `simple_modal_service`, `flippers`). If similar behavior is needed while porting
+  a page, it's fine to build it inline rather than looking for a 1:1 legacy service to copy.
+
+### Won't migrate
+
+Nothing has been decided against yet — this is a placeholder. If the team decides a legacy
+page/feature will be deprecated instead of ported (rather than just not-yet-done), move its line
+here from "Not yet migrated" with a one-line reason (e.g. superseded by feature X, unused,
+backend-only), so agents don't keep re-proposing work on it.
+
+_(none yet)_
+
+### Already migrated (for reference — don't re-port these)
+
+Everything else in `seed.js`'s state table has a corresponding route in this app, including:
+`home`→dashboard, `profile`/`security`/`developer`/`admin`→`profile/*`, `analyses`/`analysis`/
+`analysis_run`→`analyses/*`, `mapping`/`dataset_list`/`dataset_detail`→`datasets/*`, `about`/
+`contact`/`api_docs`, the full `organization_*` settings family (settings, access-level-tree,
+column settings/mappings, data-quality incl. goals, cycles, labels, members, email-templates,
+derived-columns — the derived column *editor* is now a modal rather than its own route), and the
+full `inventory_*`/`inventory_detail_*`/`inventory_group_*` family (list, map, summary,
+cross-cycles, groups incl. dashboard/meters/systems, detail incl. analyses/meters/sensors/timeline/
+notes/ubids/column-detail-profiles), and `insights_program`/`insights_property`/`reports`
+(→ default-reports)/`custom_reports`/`data_view`/`portfolio_summary`.
+
+If you migrate something from the "not yet migrated" list, move its line into this section (or
+just delete the line) in the same PR. If the team instead decides *not* to port something, move
+its line to "Won't migrate" with a reason instead.


### PR DESCRIPTION
Adds `.github/copilot-instructions.md` and `MIGRATION.md` to support Copilot-assisted development and track migration of legacy AngularJS pages to this Angular app.